### PR TITLE
ci: Make Trufflehog just look at the local files for the pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,6 @@ repos:
       - id: trufflehog
         name: TruffleHog
         description: Detect secrets in your data.
-        entry: bash -c 'trufflehog git file://. --no-verification --fail --exclude-paths=.trufflehogignore'
+        entry: bash -c 'trufflehog filesystem . --no-verification --fail --exclude-paths=.trufflehogignore'
         language: system
         stages: ["commit", "push"]


### PR DESCRIPTION
I had opened it up because it was missing a file I was trying to commit, but it meant it went off check the whole of the Git history.