### PR TITLE
fix: Use legit django-celery-beat instead of deleted kwongtn fork

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -607,12 +607,14 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-celery-beat"
-version = "2.6.0"
+version = "2.7.0"
 description = "Database-backed Periodic Tasks."
 optional = false
 python-versions = ">=3.8"
-files = []
-develop = false
+files = [
+    {file = "django_celery_beat-2.7.0-py3-none-any.whl", hash = "sha256:851c680d8fbf608ca5fecd5836622beea89fa017bc2b3f94a5b8c648c32d84b1"},
+    {file = "django_celery_beat-2.7.0.tar.gz", hash = "sha256:8482034925e09b698c05ad61c36ed2a8dbc436724a3fe119215193a4ca6dc967"},
+]
 
 [package.dependencies]
 celery = ">=5.2.3,<6.0"
@@ -621,12 +623,6 @@ Django = ">=2.2,<5.2"
 django-timezone-field = ">=5.0"
 python-crontab = ">=2.3.4"
 tzdata = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/kwongtn/django-celery-beat"
-reference = "fix/restrict-setuptools-to-max-v71"
-resolved_reference = "1f013413bbbeaa03f9c377297c865ac633ceae6a"
 
 [[package]]
 name = "django-environ"
@@ -2376,4 +2372,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "3bc3329ddbb19eea1adc7ad7dfd50e1b5eba56084fe5b052446c0f6e51da6784"
+content-hash = "5bc4b442b5e8137fd330ed4f1b020844bd925ce8f648187b00ebf708ff2862a0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requests = "^2.32.2"
 tenacity = ">=8.2.3,<8.4.0"
 normality = "^2.5.0"
 jinja2 = "^3.1.4"
-django-celery-beat = {git = "https://github.com/kwongtn/django-celery-beat", rev = "fix/restrict-setuptools-to-max-v71"}
+django-celery-beat = "^2.7.0"
 sentry-sdk = "^2.8.0"
 pytest-env = "^1.1.3"
 pytest-django = "^4.8.0"


### PR DESCRIPTION
We started getting this on poetry install...

```
Failed to clone https://github.com/kwongtn/django-celery-beat, check your git configuration and permissions for this repository.
```

We were pinned to[kwongtn:fix/restrict-setuptools-to-max-v71](https://github.com/kwongtn/django-celery-beat/tree/fix/restrict-setuptools-to-max-v71) fork/branch which no longer exists.

[Related pull request](https://github.com/celery/django-celery-beat/pull/771) was merged in July, reverting to using the legit version of the package.