### PR TITLE
fix: operator precedence bug

### DIFF
--- a/release-config.json
+++ b/release-config.json
@@ -6,7 +6,7 @@
         "include-v-in-tag": false,
         "draft": false,
         "pull-request-header": ":robot: Next release",
-        "pull-request-footer": " "
+        "pull-request-footer": " ",
         "bootstrap-sha": "ea8827dee679cd97cb7dd8b532063d32e36f89aa"
     }
   }

--- a/tests/browser/smoke/test_landing_page.py
+++ b/tests/browser/smoke/test_landing_page.py
@@ -5,8 +5,9 @@ from http import HTTPStatus
 
 
 def test_page_loads_with_title_and_has_success_ticks():
-    url = os.getenv("WEB_SERVICE_URL") or "http://localhost:8080/" + "?json=true"
-    with urllib.request.urlopen(url) as response:
+    url = os.getenv("WEB_SERVICE_URL") or "http://localhost:8080/"
+
+    with urllib.request.urlopen(f"{url}?json=true") as response:
         data = json.loads(response.read())
 
         assert response.status == HTTPStatus.OK


### PR DESCRIPTION
`+` binds more tightly than `or`, so the "?json=true" was only added to the local URL

---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
