### PR TITLE
fix: Fixed extra slash in maintenance page test

### DIFF
--- a/tests/browser/maintenance_pages/offline/test_landing_page_offline.py
+++ b/tests/browser/maintenance_pages/offline/test_landing_page_offline.py
@@ -42,7 +42,7 @@ def test_frontend_to_api(page: Page):
         ),
     )
     web_service_url = os.getenv("WEB_SERVICE_URL")
-    test_api_url = f"{web_service_url}/test-api"
+    test_api_url = f"{web_service_url}test-api"
     expected_api_service_url = os.getenv("API_SERVICE_URL")
 
     response = page.goto(test_api_url)


### PR DESCRIPTION
Addresses E2E test failure

---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base
### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
