### PR TITLE
fix: Update builder image (off-ticket)

### DIFF
--- a/.copilot/config.yml
+++ b/.copilot/config.yml
@@ -1,6 +1,6 @@
 repository: demodjango/application
 builder:
   name: paketobuildpacks/builder-jammy-base
-  version: 0.4.240
+  version: 0.4.409
 packages:
   - libpq-dev


### PR DESCRIPTION
Update `ci-image-builder` builder `paketobuildpacks/builder-jammy-base` to `0.4.409`

Tested building and deploying demodjango

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] If the work includes user interface changes, before and after screenshots included in description
- [ ] Includes any applicable changes to the documentation in this code base

### Tasks:
- [ ] [Run the end to end tests for this branch]([https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests](https://github.com/uktrade/platform-end-to-end-tests?tab=readme-ov-file#running-the-tests)) and confirm that they are passing
